### PR TITLE
Fix box rendering overflow

### DIFF
--- a/lib/garnish/renderer/box.ex
+++ b/lib/garnish/renderer/box.ex
@@ -128,7 +128,7 @@ defmodule Garnish.Renderer.Box do
         },
         %Position{x: x, y: y}
       ) do
-    x in x1..x2 && y in y1..y2
+    x in x1..x2//1 && y in y1..y2//1
   end
 
   def from_dimensions(width, height, origin \\ %Position{x: 0, y: 0}) do


### PR DESCRIPTION
Fixes the box rendering to not overflow by ensuring the ranges go upwards only.

Without fix:  
![Screenshot 2025-04-21 at 14 29 11](https://github.com/user-attachments/assets/2837b074-bbac-4fc1-9315-a6a66a6a3996)  

With fix:  

![Screenshot 2025-04-21 at 14 28 50](https://github.com/user-attachments/assets/75cb4ac2-579f-4de8-a40f-1239331bfd4e)
