### PR TITLE
Fix struct update warnings on Elixir 1.17+

### DIFF
--- a/lib/garnish/renderer/box.ex
+++ b/lib/garnish/renderer/box.ex
@@ -88,21 +88,15 @@ defmodule Garnish.Renderer.Box do
   @doc """
   Given a box, returns a slice of the y axis with `n` rows from the top.
   """
-  def head(box, n) do
-    %Box{
-      box
-      | bottom_right: %Position{box.bottom_right | y: box.top_left.y + n - 1}
-    }
+  def head(%Box{bottom_right: %Position{} = br} = box, n) do
+    %Box{box | bottom_right: %Position{br | y: box.top_left.y + n - 1}}
   end
 
   @doc """
   Given a box, returns a slice of the y axis with `n` rows from the bottom.
   """
-  def tail(box, n) do
-    %Box{
-      box
-      | top_left: %Position{box.top_left | y: box.bottom_right.y - n + 1}
-    }
+  def tail(%Box{top_left: %Position{} = tl} = box, n) do
+    %Box{box | top_left: %Position{tl | y: box.bottom_right.y - n + 1}}
   end
 
   def top_left(%Box{top_left: top_left}), do: top_left

--- a/lib/garnish/renderer/cells.ex
+++ b/lib/garnish/renderer/cells.ex
@@ -36,7 +36,7 @@ defmodule Garnish.Renderer.Cells do
   Given a starting position, orientation and cell template, returns a cell
   generator which can be used to iteratively generate a row or column of cells.
   """
-  def generator(position, orientation, template \\ Cell.empty()) do
+  def generator(position, orientation, %Cell{} = template \\ Cell.empty()) do
     fn {char_or_binary, offset} ->
       %Cell{
         template

--- a/lib/garnish/renderer/element/panel.ex
+++ b/lib/garnish/renderer/element/panel.ex
@@ -22,7 +22,7 @@ defmodule Garnish.Renderer.Element.Panel do
   end
 
   def render(
-        %Canvas{render_box: box} = canvas,
+        %Canvas{render_box: %Box{} = box} = canvas,
         %Element{attributes: attrs, children: children},
         render_fn
       ) do
@@ -30,7 +30,8 @@ defmodule Garnish.Renderer.Element.Panel do
     constrained_canvas = constrain_canvas(canvas, attrs[:height])
     padding = attrs[:padding] || @default_padding
 
-    rendered_canvas =
+    %Canvas{} =
+      rendered_canvas =
       constrained_canvas
       |> Canvas.padded(padding + @border_width)
       |> render_fn.(children)
@@ -67,7 +68,7 @@ defmodule Garnish.Renderer.Element.Panel do
   defp title_position(box),
     do: Position.translate_x(box.top_left, @title_offset_x)
 
-  defp wrapper_canvas(rendered_canvas, original_canvas, fill?) do
+  defp wrapper_canvas(%Canvas{} = rendered_canvas, original_canvas, fill?) do
     %Canvas{
       rendered_canvas
       | render_box:
@@ -81,7 +82,7 @@ defmodule Garnish.Renderer.Element.Panel do
 
   defp wrapper_box(_rendered_box, original_box, true), do: original_box
 
-  defp wrapper_box(rendered_box, original_box, false),
+  defp wrapper_box(rendered_box, %Box{} = original_box, false),
     do: %Box{
       original_box
       | bottom_right: %Position{

--- a/lib/garnish/renderer/element/row.ex
+++ b/lib/garnish/renderer/element/row.ex
@@ -36,7 +36,7 @@ defmodule Garnish.Renderer.Element.Row do
     |> Enum.max(fn -> 0 end)
   end
 
-  defp reduce_columns(render_fun, {el, column_box}, {canvas, boxes}) do
+  defp reduce_columns(render_fun, {el, column_box}, {%Canvas{} = canvas, boxes}) do
     column_canvas = %Canvas{canvas | render_box: column_box}
     canvas = render_fun.(column_canvas, el)
     {canvas, [canvas.render_box | boxes]}

--- a/lib/garnish/renderer/element/table.ex
+++ b/lib/garnish/renderer/element/table.ex
@@ -30,7 +30,7 @@ defmodule Garnish.Renderer.Element.Table do
   defp render_table_row(%Canvas{} = canvas, row, col_sizes) do
     row.children
     |> Enum.zip(col_sizes)
-    |> Enum.reduce({canvas, 0}, fn {cell, col_size}, {acc_canvas, offset} ->
+    |> Enum.reduce({canvas, 0}, fn {%Element{} = cell, col_size}, {acc_canvas, offset} ->
       new_cell = %Element{
         cell
         | attributes: Map.merge(row.attributes, cell.attributes)

--- a/lib/garnish/renderer/element/viewport.ex
+++ b/lib/garnish/renderer/element/viewport.ex
@@ -31,7 +31,7 @@ defmodule Garnish.Renderer.Element.Viewport do
     }
   end
 
-  defp translate_bottom_right(box, dx, dy) do
+  defp translate_bottom_right(%Box{} = box, dx, dy) do
     %Box{box | bottom_right: Position.translate(box.bottom_right, dx, dy)}
   end
 
@@ -39,7 +39,7 @@ defmodule Garnish.Renderer.Element.Viewport do
     %Position{x: x0, y: y0} = box.top_left
 
     new_cells =
-      for {%Position{x: x, y: y}, cell} <- cells,
+      for {%Position{x: x, y: y}, %Cell{} = cell} <- cells,
           x + dx >= x0,
           y + dy >= y0,
           into: %{} do

--- a/lib/garnish/renderer/text.ex
+++ b/lib/garnish/renderer/text.ex
@@ -21,8 +21,9 @@ defmodule Garnish.Renderer.Text do
   end
 
   def render_group(canvas, text_elements, attrs \\ %{}) do
-    rendered_canvas =
-      Enum.reduce(text_elements, canvas, fn el, canvas ->
+    %Canvas{} =
+      rendered_canvas =
+      Enum.reduce(text_elements, canvas, fn %Element{} = el, canvas ->
         element = %Element{el | attributes: Map.merge(attrs, el.attributes)}
         render_group_member(canvas, element)
       end)


### PR DESCRIPTION
Add %Struct{} pattern matches so the compiler can verify struct types in update expressions like %Box{var | field: value}.

Elixir 1.17 introduced warnings when the compiler cannot verify that a variable used in a struct update is actually that struct type. This adds the minimal pattern matches needed to satisfy the check across 7 files.

Thanks for garnish -- I'm using it as a secondary ui for a music playing app.

<img width="1466" height="858" alt="image" src="https://github.com/user-attachments/assets/575e6f71-e542-40fb-ad68-d80affddb990" />
