### PR TITLE
Fix set_colors when only foreground or background is set

### DIFF
--- a/lib/garnish.ex
+++ b/lib/garnish.ex
@@ -339,6 +339,14 @@ defmodule Garnish do
 
   defp set_colors(0, 0, _), do: <<>>
 
+  defp set_colors(fg, 0, term) do
+    <<term.setaf(fg - 1)::binary>>
+  end
+
+  defp set_colors(0, bg, term) do
+    <<term.setab(bg - 1)::binary>>
+  end
+
   defp set_colors(fg, bg, term) do
     <<term.setaf(fg - 1)::binary, term.setab(bg - 1)::binary>>
   end


### PR DESCRIPTION
When a cell has only a foreground color (bg=0) or only a background color (fg=0), the catch-all clause would call setaf(-1) or setab(-1), producing invalid escape sequences. Add dedicated clauses for fg-only and bg-only cases.