### PR TITLE
Support tmux and screen terminal types

### DIFF
--- a/lib/garnish/term_info.ex
+++ b/lib/garnish/term_info.ex
@@ -37,6 +37,9 @@ defmodule Garnish.TermInfo do
 
   @supported %{
     "xterm-256color" => Garnish.TermInfo.Xterm256color,
+    "tmux-256color" => Garnish.TermInfo.Xterm256color,
+    "screen-256color" => Garnish.TermInfo.Xterm256color,
+    "screen" => Garnish.TermInfo.Xterm,
     "xterm" => Garnish.TermInfo.Xterm,
     "linux" => Garnish.TermInfo.Linux,
     "rxvt" => Garnish.TermInfo.Rxvt


### PR DESCRIPTION
Add tmux-256color, screen-256color, and screen to the supported terminals map. These terminal emulators use the same escape sequences as their xterm counterparts.

Fixes #1