### PR TITLE
Support 256 colors

### DIFF
--- a/lib/garnish.ex
+++ b/lib/garnish.ex
@@ -339,6 +339,14 @@ defmodule Garnish do
 
   defp set_colors(0, 0, _), do: <<>>
 
+  defp set_colors(fg, 0, term) do
+    <<term.setaf(fg - 1)::binary>>
+  end
+
+  defp set_colors(0, bg, term) do
+    <<term.setab(bg - 1)::binary>>
+  end
+
   defp set_colors(fg, bg, term) do
     <<term.setaf(fg - 1)::binary, term.setab(bg - 1)::binary>>
   end

--- a/lib/garnish/renderer/attributes.ex
+++ b/lib/garnish/renderer/attributes.ex
@@ -5,15 +5,16 @@ defmodule Garnish.Renderer.Attributes do
 
   alias Garnish.Constants
 
-  @valid_color_codes Constants.colors() |> Map.values()
   @valid_attribute_codes Constants.attributes() |> Map.values()
 
+  # Accept any integer in the valid range for termbox colors.
+  # 0 = default, 1-8 = standard colors, 9-256 = extended 256-color palette.
   def to_terminal_color(code)
-      when is_integer(code) and code in @valid_color_codes do
+      when is_integer(code) and code >= 0 and code <= 256 do
     code
   end
 
-  def to_terminal_color(name) do
+  def to_terminal_color(name) when is_atom(name) do
     Constants.color(name)
   end
 

--- a/lib/garnish/term_info/linux.ex
+++ b/lib/garnish/term_info/linux.ex
@@ -54,13 +54,13 @@ defmodule Garnish.TermInfo.Linux do
 
   def setaf(fg) when is_integer(fg) do
     <<
-      "\e[", <<?3, Integer.to_string(fg)::binary>>, ?m
+      "\e[", <<?3, Integer.to_string(rem(fg, 8))::binary>>, ?m
     >>
   end
 
   def setab(bg) when is_integer(bg) do
     <<
-      "\e[", <<?4, Integer.to_string(bg)::binary>>, ?m
+      "\e[", <<?4, Integer.to_string(rem(bg, 8))::binary>>, ?m
     >>
   end
 

--- a/lib/garnish/term_info/rxvt.ex
+++ b/lib/garnish/term_info/rxvt.ex
@@ -96,13 +96,13 @@ defmodule Garnish.TermInfo.Rxvt do
 
   def setaf(fg) when is_integer(fg) do
     <<
-      "\e[", <<?3, Integer.to_string(fg)::binary>>, ?m
+      "\e[", <<?3, Integer.to_string(rem(fg, 8))::binary>>, ?m
     >>
   end
 
   def setab(bg) when is_integer(bg) do
     <<
-      "\e[", <<?4, Integer.to_string(bg)::binary>>, ?m
+      "\e[", <<?4, Integer.to_string(rem(bg, 8))::binary>>, ?m
     >>
   end
 

--- a/lib/garnish/term_info/xterm.ex
+++ b/lib/garnish/term_info/xterm.ex
@@ -108,13 +108,13 @@ defmodule Garnish.TermInfo.Xterm do
 
   def setaf(fg) when is_integer(fg) do
     <<
-      "\e[", <<?3, Integer.to_string(fg)::binary>>, ?m
+      "\e[", <<?3, Integer.to_string(rem(fg, 8))::binary>>, ?m
     >>
   end
 
   def setab(bg) when is_integer(bg) do
     <<
-      "\e[", <<?4, Integer.to_string(bg)::binary>>, ?m
+      "\e[", <<?4, Integer.to_string(rem(bg, 8))::binary>>, ?m
     >>
   end
 

--- a/test/garnish/renderer/attributes_test.exs
+++ b/test/garnish/renderer/attributes_test.exs
@@ -13,9 +13,25 @@ defmodule Garnish.Renderer.AttributesTest do
                Constants.color(:red)
     end
 
-    test "when invalid" do
-      assert_raise KeyError, fn ->
-        Attributes.to_terminal_color(1000)
+    test "with 256-color index" do
+      # xterm color 208 (orange) is stored as 209 (offset by 1)
+      assert Attributes.to_terminal_color(209) == 209
+    end
+
+    test "with maximum 256-color index" do
+      # xterm color 255 is stored as 256
+      assert Attributes.to_terminal_color(256) == 256
+    end
+
+    test "when out of range" do
+      assert_raise FunctionClauseError, fn ->
+        Attributes.to_terminal_color(257)
+      end
+    end
+
+    test "when negative" do
+      assert_raise FunctionClauseError, fn ->
+        Attributes.to_terminal_color(-1)
       end
     end
   end


### PR DESCRIPTION
Widen to_terminal_color/1 to accept any integer 0-256 so elements can use the full xterm palette. Clamp with rem(n, 8) in 8-color terminals (xterm, linux, rxvt) so out-of-range values degrade gracefully instead of producing invalid escape sequences.